### PR TITLE
Fixed preferred names for Malešice neighbourhood

### DIFF
--- a/data/859/007/69/85900769.geojson
+++ b/data/859/007/69/85900769.geojson
@@ -28,28 +28,28 @@
     "mz:tier_locality":5,
     "mz:tier_metro":30,
     "name:ces_x_colloquial":[
-        "Malesice"
+        "Male\u0161ice"
     ],
     "name:ces_x_preferred":[
-        "Stra\u0161nice"
+        "Male\u0161ice"
     ],
     "name:ces_x_variant":[
         "Male\u0161ice"
     ],
     "name:eng_x_preferred":[
-        "Malesice"
+        "Male\u0161ice"
     ],
     "name:eng_x_variant":[
         "Male\u0161ice"
     ],
     "name:nld_x_preferred":[
-        "Stra\u0161nice"
+        "Male\u0161ice"
     ],
     "name:pol_x_preferred":[
-        "Stra\u0161nice"
+        "Male\u0161ice"
     ],
     "name:slk_x_preferred":[
-        "Stra\u0161nice"
+        "Male\u0161ice"
     ],
     "qs:gn_adm0_cc":"CZ",
     "qs:gn_fcode":"PPLX",


### PR DESCRIPTION
Unified pnames to Malešice as Strašnice is name of adjacent neighbourhood