### PR TITLE
cz concordances, placetype local, and more

### DIFF
--- a/data/856/331/05/85633105.geojson
+++ b/data/856/331/05/85633105.geojson
@@ -1586,6 +1586,7 @@
         "hasc:id":"CZ",
         "icao:code":"OK",
         "ioc:id":"CZE",
+        "iso:code":"CZ",
         "itu:id":"CZE",
         "loc:id":"n90718759",
         "m49:code":"203",
@@ -1600,6 +1601,7 @@
         "wk:page":"Czech Republic",
         "wmo:id":"CZ"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"CZ",
     "wof:country_alpha3":"CZE",
     "wof:geom_alt":[
@@ -1621,7 +1623,7 @@
     "wof:lang_x_spoken":[
         "ces"
     ],
-    "wof:lastmodified":1694492248,
+    "wof:lastmodified":1695881361,
     "wof:name":"Czech Republic",
     "wof:parent_id":102191581,
     "wof:placetype":"country",

--- a/data/856/824/15/85682415.geojson
+++ b/data/856/824/15/85682415.geojson
@@ -393,11 +393,17 @@
         "gn:id":3339537,
         "gp:id":20070502,
         "hasc:id":"CZ.CK",
+        "iso:code":"CZ-JC",
         "iso:id":"CZ-JC",
+        "qs:local_id":"31",
         "wd:id":"Q188373"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"CZ",
-    "wof:geomhash":"a6909e2b0b8095cfa2f4f05a947aac98",
+    "wof:geomhash":"240cd4f27a9f1e65e47255eae11c2f08",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -412,7 +418,7 @@
     "wof:lang_x_spoken":[
         "ces"
     ],
-    "wof:lastmodified":1690869330,
+    "wof:lastmodified":1695885200,
     "wof:name":"Jiho\u010desk\u00fd",
     "wof:parent_id":85633105,
     "wof:placetype":"region",

--- a/data/856/824/19/85682419.geojson
+++ b/data/856/824/19/85682419.geojson
@@ -380,12 +380,18 @@
         "gn:id":3339578,
         "gp:id":20070469,
         "hasc:id":"CZ.ZK",
+        "iso:code":"CZ-ZL",
         "iso:id":"CZ-ZL",
+        "qs:local_id":"72",
         "unlc:id":"CZ-ZL",
         "wd:id":"Q192536"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"CZ",
-    "wof:geomhash":"78df37dfc87b36a3ce8f874dd1d11fe3",
+    "wof:geomhash":"43994fcc731086b9b7ef9c124ae889da",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -400,7 +406,7 @@
     "wof:lang_x_spoken":[
         "ces"
     ],
-    "wof:lastmodified":1690869327,
+    "wof:lastmodified":1695885200,
     "wof:name":"Zl\u00ednsk\u00fd",
     "wof:parent_id":85633105,
     "wof:placetype":"region",

--- a/data/856/824/23/85682423.geojson
+++ b/data/856/824/23/85682423.geojson
@@ -388,12 +388,18 @@
         "gn:id":3339536,
         "gp:id":20070503,
         "hasc:id":"CZ.BK",
+        "iso:code":"CZ-JM",
         "iso:id":"CZ-JM",
+        "qs:local_id":"64",
         "unlc:id":"CZ-JM",
         "wd:id":"Q192697"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"CZ",
-    "wof:geomhash":"5c5c1026a582cef08e9180afccf419d9",
+    "wof:geomhash":"4f9f8cf2adcb17207e1af319846876f8",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -408,7 +414,7 @@
     "wof:lang_x_spoken":[
         "ces"
     ],
-    "wof:lastmodified":1690869329,
+    "wof:lastmodified":1695885200,
     "wof:name":"Jihomoravsk\u00fd",
     "wof:parent_id":85633105,
     "wof:placetype":"region",

--- a/data/856/824/29/85682429.geojson
+++ b/data/856/824/29/85682429.geojson
@@ -392,12 +392,18 @@
         "gn:id":3339538,
         "gp:id":20070467,
         "hasc:id":"CZ.JK",
+        "iso:code":"CZ-VY",
         "iso:id":"CZ-VY",
+        "qs:local_id":"63",
         "unlc:id":"CZ-VY",
         "wd:id":"Q190930"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"CZ",
-    "wof:geomhash":"bf229280ac6214681b2b2c151d5e4872",
+    "wof:geomhash":"dfbc0a38149b0acd06d53dfdf446456b",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -412,7 +418,7 @@
     "wof:lang_x_spoken":[
         "ces"
     ],
-    "wof:lastmodified":1690869326,
+    "wof:lastmodified":1695885200,
     "wof:name":"Vyso\u010dina",
     "wof:parent_id":85633105,
     "wof:placetype":"region",

--- a/data/856/824/33/85682433.geojson
+++ b/data/856/824/33/85682433.geojson
@@ -382,11 +382,17 @@
         "gn:id":3339575,
         "gp:id":20070501,
         "hasc:id":"CZ.PK",
+        "iso:code":"CZ-PL",
         "iso:id":"CZ-PL",
+        "qs:local_id":"32",
         "wd:id":"Q46070"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"CZ",
-    "wof:geomhash":"08dd48417a8da9b0eebc02bfef4e8b33",
+    "wof:geomhash":"a312426f28dd71aaf52626e28ef15541",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -401,7 +407,7 @@
     "wof:lang_x_spoken":[
         "ces"
     ],
-    "wof:lastmodified":1690869326,
+    "wof:lastmodified":1695885201,
     "wof:name":"Plze\u0148sk\u00fd",
     "wof:parent_id":85633105,
     "wof:placetype":"region",

--- a/data/856/824/37/85682437.geojson
+++ b/data/856/824/37/85682437.geojson
@@ -826,12 +826,18 @@
         "gn:id":3067695,
         "gp:id":20070472,
         "hasc:id":"CZ.PM",
+        "iso:code":"CZ-PR",
         "iso:id":"CZ-PR",
+        "qs:local_id":"10",
         "unlc:id":"CZ-PR",
         "wd:id":"Q1085"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"CZ",
-    "wof:geomhash":"cef371ad77a3be15cea2a6188e1530b3",
+    "wof:geomhash":"9be2dc83ee3ecdfeea36247846c85c39",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -846,7 +852,7 @@
     "wof:lang_x_spoken":[
         "ces"
     ],
-    "wof:lastmodified":1690869329,
+    "wof:lastmodified":1695885201,
     "wof:name":"Hlavn\u00ed m\u011bsto Praha",
     "wof:parent_id":85633105,
     "wof:placetype":"region",

--- a/data/856/824/43/85682443.geojson
+++ b/data/856/824/43/85682443.geojson
@@ -377,12 +377,18 @@
         "gn:id":3339574,
         "gp:id":20070465,
         "hasc:id":"CZ.EK",
+        "iso:code":"CZ-PA",
         "iso:id":"CZ-PA",
+        "qs:local_id":"53",
         "unlc:id":"CZ-PA",
         "wd:id":"Q193317"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"CZ",
-    "wof:geomhash":"a0f69b56f9be419a96805e2abb317f45",
+    "wof:geomhash":"c5ba517e0edf810d08126e3199638507",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -397,7 +403,7 @@
     "wof:lang_x_spoken":[
         "ces"
     ],
-    "wof:lastmodified":1690869328,
+    "wof:lastmodified":1695885201,
     "wof:name":"Pardubick\u00fd",
     "wof:parent_id":85633105,
     "wof:placetype":"region",

--- a/data/856/824/47/85682447.geojson
+++ b/data/856/824/47/85682447.geojson
@@ -355,12 +355,18 @@
         "gn:id":3339539,
         "gp:id":20070500,
         "hasc:id":"CZ.KK",
+        "iso:code":"CZ-KA",
         "iso:id":"CZ-KA",
+        "qs:local_id":"41",
         "unlc:id":"CZ-KA",
         "wd:id":"Q191091"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"CZ",
-    "wof:geomhash":"9583dabf427fe7a8a80cdcccd70c48ba",
+    "wof:geomhash":"d09ad3dd0749e972da124b7045e55e8f",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -375,7 +381,7 @@
     "wof:lang_x_spoken":[
         "ces"
     ],
-    "wof:lastmodified":1690869330,
+    "wof:lastmodified":1695885201,
     "wof:name":"Karlovarsk\u00fd",
     "wof:parent_id":85633105,
     "wof:placetype":"region",

--- a/data/856/824/51/85682451.geojson
+++ b/data/856/824/51/85682451.geojson
@@ -395,12 +395,18 @@
         "gn:id":3339573,
         "gp:id":20070471,
         "hasc:id":"CZ.VK",
+        "iso:code":"CZ-MO",
         "iso:id":"CZ-MO",
+        "qs:local_id":"80",
         "unlc:id":"CZ-MO",
         "wd:id":"Q190550"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"CZ",
-    "wof:geomhash":"bd968cffcf9f47ae3bbc2109a7dc8ac3",
+    "wof:geomhash":"aba1ec29618edef0a832f4ee254478af",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -415,7 +421,7 @@
     "wof:lang_x_spoken":[
         "ces"
     ],
-    "wof:lastmodified":1690869326,
+    "wof:lastmodified":1695885201,
     "wof:name":"Moravskoslezsk\u00fd",
     "wof:parent_id":85633105,
     "wof:placetype":"region",

--- a/data/856/824/55/85682455.geojson
+++ b/data/856/824/55/85682455.geojson
@@ -380,12 +380,18 @@
         "gn:id":3339542,
         "gp:id":20070470,
         "hasc:id":"CZ.OK",
+        "iso:code":"CZ-OL",
         "iso:id":"CZ-OL",
+        "qs:local_id":"71",
         "unlc:id":"CZ-OL",
         "wd:id":"Q193307"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"CZ",
-    "wof:geomhash":"13b5991f6566d20b4357022f670b529b",
+    "wof:geomhash":"c7fc9f52ff584d35326cfe8e8fa0a365",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -400,7 +406,7 @@
     "wof:lang_x_spoken":[
         "ces"
     ],
-    "wof:lastmodified":1690869329,
+    "wof:lastmodified":1695885201,
     "wof:name":"Olomouck\u00fd",
     "wof:parent_id":85633105,
     "wof:placetype":"region",

--- a/data/856/824/61/85682461.geojson
+++ b/data/856/824/61/85682461.geojson
@@ -401,11 +401,17 @@
         "gn:id":3339576,
         "gp:id":20070468,
         "hasc:id":"CZ.SK",
+        "iso:code":"CZ-ST",
         "iso:id":"CZ-ST",
+        "qs:local_id":"20",
         "wd:id":"Q188399"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"CZ",
-    "wof:geomhash":"76baa95bb1368ac081eff0435826a69e",
+    "wof:geomhash":"7d80ed1c763aaf17281d55e96417a0b3",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -420,7 +426,7 @@
     "wof:lang_x_spoken":[
         "ces"
     ],
-    "wof:lastmodified":1690869325,
+    "wof:lastmodified":1695885201,
     "wof:name":"St\u0159edo\u010desk\u00fd",
     "wof:parent_id":85633105,
     "wof:placetype":"region",

--- a/data/856/824/65/85682465.geojson
+++ b/data/856/824/65/85682465.geojson
@@ -379,12 +379,18 @@
         "gn:id":3339540,
         "gp:id":20070466,
         "hasc:id":"CZ.HK",
+        "iso:code":"CZ-KR",
         "iso:id":"CZ-KR",
+        "qs:local_id":"52",
         "unlc:id":"CZ-KR",
         "wd:id":"Q193295"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"CZ",
-    "wof:geomhash":"379c6f84139ca413e4afaf2b7542a2cb",
+    "wof:geomhash":"15bd94a17158cbfdb50d862102b487ec",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -399,7 +405,7 @@
     "wof:lang_x_spoken":[
         "ces"
     ],
-    "wof:lastmodified":1690869328,
+    "wof:lastmodified":1695885201,
     "wof:name":"Kr\u00e1lov\u00e9hradeck\u00fd",
     "wof:parent_id":85633105,
     "wof:placetype":"region",

--- a/data/856/824/69/85682469.geojson
+++ b/data/856/824/69/85682469.geojson
@@ -367,12 +367,18 @@
         "gn:id":3339577,
         "gp:id":20070499,
         "hasc:id":"CZ.UK",
+        "iso:code":"CZ-US",
         "iso:id":"CZ-US",
+        "qs:local_id":"42",
         "unlc:id":"CZ-US",
         "wd:id":"Q192702"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"CZ",
-    "wof:geomhash":"a7ee73bab535460e166be066890063db",
+    "wof:geomhash":"4056fab76e864b179e647b33a09fc4e3",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -387,7 +393,7 @@
     "wof:lang_x_spoken":[
         "ces"
     ],
-    "wof:lastmodified":1690869325,
+    "wof:lastmodified":1695885201,
     "wof:name":"\u00dasteck\u00fd",
     "wof:parent_id":85633105,
     "wof:placetype":"region",

--- a/data/856/824/73/85682473.geojson
+++ b/data/856/824/73/85682473.geojson
@@ -368,12 +368,18 @@
         "gn:id":3339541,
         "gp:id":20070498,
         "hasc:id":"CZ.LK",
+        "iso:code":"CZ-LI",
         "iso:id":"CZ-LI",
+        "qs:local_id":"51",
         "unlc:id":"CZ-LI",
         "wd:id":"Q193266"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"CZ",
-    "wof:geomhash":"a54ece428da3aa14d3bb68d57d339361",
+    "wof:geomhash":"92efccb5db9e280e3e10a03b953014f9",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -388,7 +394,7 @@
     "wof:lang_x_spoken":[
         "ces"
     ],
-    "wof:lastmodified":1690869327,
+    "wof:lastmodified":1695885202,
     "wof:name":"Libereck\u00fd",
     "wof:parent_id":85633105,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.